### PR TITLE
Add CarthageCacheExistAction

### DIFF
--- a/lib/fastlane/plugin/carthage_cache/actions/carthage_cache_exist.rb
+++ b/lib/fastlane/plugin/carthage_cache/actions/carthage_cache_exist.rb
@@ -1,0 +1,33 @@
+module Fastlane
+  module Actions
+    class CarthageCacheExistAction < Action
+      def self.run(params)
+        UI.message("Checking Amazon S3 for matching Carthage cache...")
+        check = `bundle exec carthage_cache exist --bucket-name #{params[:bucket]} -s 2>&1`.chomp
+        check == "true"
+      end
+
+      def self.description
+        %q{Check if Carthage cache exists for Cartfile.resolved in Amazon S3}
+      end
+
+      def self.authors
+        [%q{bfcrampton}]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :bucket,
+                                  env_name: "CARTHAGE_CACHE_BUCKET",
+                               description: "Amazon S3 bucket name which caches your Carthage build",
+                                  optional: false,
+                                      type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac, :tvos, :watchos].include?(platform)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows for easy switching on whether or not a cache exists for the current `Cartfile.resolved`. For example:

``` ruby
if carthage_cache_exist(bucket: 'bucket-name')
      carthage_cache_install(bucket: 'bucket-name')
else
      carthage(
            platform: 'iOS',
            use_binaries: false,
      )

      if publish_carthage_cache
            carthage_cache_publish(bucket: 'bucket-name')
      end
end
```
